### PR TITLE
Correct a German translation

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -699,7 +699,7 @@ msgstr "Zutaten"
 #: templates/recipe/recipe_cook.html:32
 #: templates/recipe/recipe_detail.html:201
 msgid "Directions"
-msgstr "Anfahrt"
+msgstr "Zubereitung"
 
 #: templates/recipe/recipe_detail.html:115
 msgid "print"


### PR DESCRIPTION
The translation was correct, but in wrong context. »Anfahrt« is used in case of e.g. describing on how to find the way to a restaurant. But in this case we need something like cooking instructions.